### PR TITLE
Adds `$wgMatomoAnalyticsDisableJS` to allow disabling of JS tracking code globally

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 == ChangeLog for MatomoAnalytics ==
 
+=== 1.0.2 (30-05-2019) ===
+* Adds `$wgMatomoAnalyticsDisableJS` to allow disabling of JS tracking code globally.
+
 === 1.0.1 (30-05-2019) ===
 * Drop unnecessary variable assignments.
 

--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"Southparkfan"
 	],
 	"url": "https://github.com/miraheze/MatomoAnalytics",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"descriptionmsg": "matomoanalytics-desc",
 	"type": "specialpage",
 	"AvailableRights": [

--- a/extension.json
+++ b/extension.json
@@ -92,6 +92,11 @@
 			"description": "Boolean. Whether or not to use the database for tracking site IDs.",
 			"public": true,
 			"value": false
+		},
+		"MatomoAnalyticsDisableJS": {
+			"description": "Boolean. Whether or not to add Javascript tracking code to pages.",
+			"public": true,
+			"value": false
 		}
 	},
 	"ConfigRegistry": {

--- a/includes/MatomoAnalyticsHooks.php
+++ b/includes/MatomoAnalyticsHooks.php
@@ -37,6 +37,12 @@ class MatomoAnalyticsHooks {
 	*/
 	public static function matomoScript( $skin, &$text = '' ) {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'matomoanalytics' );
+
+		// Check if JS tracking is disabled and bow out early
+		if ( $config->get( 'MatomoAnalyticsDisableJS' ) === true ) {
+			return true;
+		}
+
 		$user = RequestContext::getMain()->getUser();
 		$mAId = MatomoAnalytics::getSiteID( $config->get( 'DBname' ) );
 


### PR DESCRIPTION
`$wgMatomoAnalyticsDisableJS` , default `false`, when set to `true` disables adding JS tracking code regardless of the `noanalytics` right