### PR TITLE
Introduce wgMatomoAnalyticsForGetRequest config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 == ChangeLog for MatomoAnalytics ==
 
+=== 1.0.5 (12-12-2020) ===
+* Introduce wgMatomoAnalyticsForGetRequest config to force GET requests and reverts back to matomo 3 way of tracking.
+
 === 1.0.4 (20-07-2020) ===
 * Updates Matomo javascript to the version used in Matomo 3.14.0.
 

--- a/extension.json
+++ b/extension.json
@@ -102,13 +102,12 @@
 			"description": "Boolean. Whether or not to disable cookies being set by Matomo.",
 			"public": true,
 			"value": false
-		}
+		},
 		"MatomoAnalyticsForGetRequest": {
 			"description": "Boolean. Whether or not you want to foce GET requests which also disables beacon. Reverts back to matomo 3 behaviour of tracking.",
 			"public": true,
 			"value": false
 		}
-		MatomoAnalyticsForGetRequest
 	},
 	"ConfigRegistry": {
 		"matomoanalytics": "GlobalVarConfig::newInstance"

--- a/extension.json
+++ b/extension.json
@@ -103,6 +103,12 @@
 			"public": true,
 			"value": false
 		}
+		"MatomoAnalyticsForGetRequest": {
+			"description": "Boolean. Whether or not you want to foce GET requests which also disables beacon. Reverts back to matomo 3 behaviour of tracking.",
+			"public": true,
+			"value": false
+		}
+		MatomoAnalyticsForGetRequest
 	},
 	"ConfigRegistry": {
 		"matomoanalytics": "GlobalVarConfig::newInstance"

--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"Southparkfan"
 	],
 	"url": "https://github.com/miraheze/MatomoAnalytics",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"descriptionmsg": "matomoanalytics-desc",
 	"type": "specialpage",
 	"AvailableRights": [

--- a/includes/MatomoAnalyticsHooks.php
+++ b/includes/MatomoAnalyticsHooks.php
@@ -65,12 +65,16 @@ class MatomoAnalyticsHooks {
 			$urltitle = $title->getPrefixedURL();
 			$userType = $user->isLoggedIn() ? "User" : "Anonymous";
 			$cookieDisable = (int)$config->get( 'MatomoAnalyticsDisableCookie' );
+			$forceGetRequest = (int)$config->get( 'MatomoAnalyticsForGetRequest' );
 			$text .= <<<SCRIPT
 				<!-- Matomo -->
 				<script type="text/javascript">
 				var _paq = window._paq = window._paq || [];
 				if ( {$cookieDisable} ) {
 					_paq.push(['disableCookies']);
+				}
+				if ( {$forceGetRequest} ) {
+					_paq.push(['setRequestMethod', 'GET']);
 				}
 				_paq.push(['trackPageView']);
 				_paq.push(['enableLinkTracking']);


### PR DESCRIPTION
Allows users to force GET requests instead of POST. This also disables beacon and fallbacks to matomo 3 default method.