### PR TITLE
MatomoAnalytics: Cache get within getSiteID

### DIFF
--- a/includes/MatomoAnalytics.php
+++ b/includes/MatomoAnalytics.php
@@ -3,6 +3,8 @@
 use MediaWiki\MediaWikiServices;
 
 class MatomoAnalytics {
+	protected static $mACache = null;
+
 	public static function addSite( $dbname ) {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'matomoanalytics' );
 
@@ -129,7 +131,11 @@ class MatomoAnalytics {
 		if ( $config->get( 'MatomoAnalyticsUseDB' ) ) {
 			$cache = ObjectCache::getLocalClusterInstance();
 			$key = $cache->makeKey( 'matomo', 'id' );
-			$cacheId = $cache->get( $key );
+			$cacheId = static::$mACache;
+			if ( $cacheId === NULL ) {
+				$cacheId = (int)$cache->get( $key );
+			}
+
 			if ( $cacheId ) {
 				return $cacheId;
 			}

--- a/includes/MatomoAnalytics.php
+++ b/includes/MatomoAnalytics.php
@@ -3,7 +3,7 @@
 use MediaWiki\MediaWikiServices;
 
 class MatomoAnalytics {
-	protected static $mACache = null;
+	protected static $mACache;
 
 	public static function addSite( $dbname ) {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'matomoanalytics' );
@@ -132,7 +132,7 @@ class MatomoAnalytics {
 			$cache = ObjectCache::getLocalClusterInstance();
 			$key = $cache->makeKey( 'matomo', 'id' );
 			$cacheId = static::$mACache;
-			if ( $cacheId === NULL ) {
+			if ( $cacheId === null ) {
 				$cacheId = (int)$cache->get( $key );
 			}
 


### PR DESCRIPTION
Lots of spammy logs with "Duplicate get(): \"test3wiki:matomo:id\" fetched 2 times"