### PR TITLE
MatomoAnalytics::getSiteID: Fix default value for when wiki isn't found

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 == ChangeLog for MatomoAnalytics ==
 
+=== 1.0.5.3 (27-02-2021) ===
+* MatomoAnalytics::getSiteID: Fix default value for when wiki isn't found 
+
 === 1.0.5.2 (08-02-2021) ===
 * Delete cache when deleting or renaming wikis.
 

--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"Southparkfan"
 	],
 	"url": "https://github.com/miraheze/MatomoAnalytics",
-	"version": "1.0.5.2",
+	"version": "1.0.5.3",
 	"descriptionmsg": "matomoanalytics-desc",
 	"type": "specialpage",
 	"AvailableRights": [

--- a/includes/MatomoAnalytics.php
+++ b/includes/MatomoAnalytics.php
@@ -145,9 +145,9 @@ class MatomoAnalytics {
 			if ( !isset( $id ) ) {
 				wfDebugLog( 'MatomoAnalytics', "could not find {$dbname} in matomo table" );
 
-				// Because site has not been found in the matomo table
-				// lets put a 0 to prevent it throwing errors.
-				return (int)0;
+				// Because the site is not found in the matomo table,
+				// we default to a value set in 'MatomoAnalyticsSiteID' which is 1.
+				return $config->get( 'MatomoAnalyticsSiteID' );
 			} else {
 				$cache->set( $key, $id );
 


### PR DESCRIPTION
Was failing with "Error in Matomo (tracker): Invalid idSite: '0'"