### PR TITLE
MatomoAnalytics: Add check within rename/add site to prevent deleting default id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 == ChangeLog for MatomoAnalytics ==
 
+=== 1.0.5.5 (28-02-2021) ===
+* MatomoAnalytics: Add check within rename/add site to prevent deleting default id
+
 === 1.0.5.4 (28-02-2021) ===
 * add extra check for $id
 

--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"Southparkfan"
 	],
 	"url": "https://github.com/miraheze/MatomoAnalytics",
-	"version": "1.0.5.4",
+	"version": "1.0.5.5",
 	"descriptionmsg": "matomoanalytics-desc",
 	"type": "specialpage",
 	"AvailableRights": [

--- a/includes/MatomoAnalytics.php
+++ b/includes/MatomoAnalytics.php
@@ -48,7 +48,7 @@ class MatomoAnalytics {
 		$siteId = static::getSiteID( $dbname );
 
 		if ( $config->get( 'MatomoAnalyticsUseDB' ) &&
-		    $siteId === $config->get( 'MatomoAnalyticsSiteID' )
+		    (int)$siteId === (int)$config->get( 'MatomoAnalyticsSiteID' )
 		) {
 			return;
 		}
@@ -91,7 +91,7 @@ class MatomoAnalytics {
 		$siteId = static::getSiteID( $old );
 
 		if ( $config->get( 'MatomoAnalyticsUseDB' ) &&
-		    $siteId === $config->get( 'MatomoAnalyticsSiteID' )
+		    (int)$siteId === (int)$config->get( 'MatomoAnalyticsSiteID' )
 		) {
 			return;
 		}

--- a/includes/MatomoAnalytics.php
+++ b/includes/MatomoAnalytics.php
@@ -47,6 +47,12 @@ class MatomoAnalytics {
 
 		$siteId = static::getSiteID( $dbname );
 
+		if ( $config->get( 'MatomoAnalyticsUseDB' ) &&
+		    $siteId === $config->get( 'MatomoAnalyticsSiteID' )
+		) {
+			return;
+		}
+
 		MediaWikiServices::getInstance()->getHttpRequestFactory()->get(
 			wfAppendQuery(
 				$config->get( 'MatomoAnalyticsServerURL' ),
@@ -83,6 +89,12 @@ class MatomoAnalytics {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'matomoanalytics' );
 
 		$siteId = static::getSiteID( $old );
+
+		if ( $config->get( 'MatomoAnalyticsUseDB' ) &&
+		    $siteId === $config->get( 'MatomoAnalyticsSiteID' )
+		) {
+			return;
+		}
 
 		MediaWikiServices::getInstance()->getHttpRequestFactory()->get(
 			wfAppendQuery(


### PR DESCRIPTION
This is a bug a deletes the default dashboard (containing analytics for all wikis).
We fix this by not deleting it or renaming if the id equals the value set in MatomoAnalyticsSiteID.