### PR TITLE
T9814: ensure matomo script isn't added more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## ChangeLog for MatomoAnalytics
 
-### 1.1.0 (26-01-2023)
+### 1.1.0 (29-01-2023)
 * Ensure matomo script isn't added more than once
 * Require MediaWiki 1.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog for MatomoAnalytics
 
+### 1.1.0 (26-01-2023)
+* Ensure matomo script isn't added more than once
+* Require MediaWiki 1.39.0
+
 ### 1.0.9 (12-01-2023)
 * Replace deprecated wfGetDB()
 

--- a/extension.json
+++ b/extension.json
@@ -6,12 +6,12 @@
 		"Universal Omega"
 	],
 	"url": "https://github.com/miraheze/MatomoAnalytics",
-	"version": "1.0.9",
+	"version": "1.1.0",
 	"descriptionmsg": "matomoanalytics-desc",
 	"license-name": "GPL-3.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.38.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"AvailableRights": [
 		"noanalytics"

--- a/includes/MatomoAnalyticsHooks.php
+++ b/includes/MatomoAnalyticsHooks.php
@@ -35,8 +35,10 @@ class MatomoAnalyticsHooks {
 	public static function matomoScript( $skin, &$text = '' ) {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'matomoanalytics' );
 
-		// Check if JS tracking is disabled and bow out early
-		if ( $config->get( 'MatomoAnalyticsDisableJS' ) === true ) {
+		static $alreadyDone = false;
+
+		// Check if JS tracking is disabled or if the script has already been added and bow out early
+		if ( $alreadyDone || $config->get( 'MatomoAnalyticsDisableJS' ) === true ) {
 			return true;
 		}
 
@@ -84,8 +86,10 @@ class MatomoAnalyticsHooks {
 				})();
 				</script>
 				<noscript><p><img src="{$serverurl}matomo.php?idsite={$id}&amp;rec=1&amp;action_name={$urltitle}" style="border:0;" alt="" /></p></noscript>
-SCRIPT;
+			SCRIPT;
 		}
+
+		$alreadyDone = true;
 
 		return true;
 	}

--- a/includes/MatomoAnalyticsHooks.php
+++ b/includes/MatomoAnalyticsHooks.php
@@ -38,11 +38,11 @@ class MatomoAnalyticsHooks {
 		static $alreadyDone = false;
 
 		// Check if JS tracking is disabled or if the script has already been added and bow out early
-		if ( $alreadyDone || $config->get( 'MatomoAnalyticsDisableJS' ) === true ) {
+		if ( $alreadyDone || $config->get( 'MatomoAnalyticsDisableJS' ) ) {
 			return true;
 		}
 
-		$user = RequestContext::getMain()->getUser();
+		$user = $skin->getUser();
 		$mAId = MatomoAnalytics::getSiteID( $config->get( 'DBname' ) );
 
 		$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
@@ -58,7 +58,7 @@ class MatomoAnalyticsHooks {
 			$jstitle = Xml::encodeJsVar( $title->getPrefixedText() );
 			$dbname = Xml::encodeJsVar( $config->get( 'DBname' ) );
 			$urltitle = $title->getPrefixedURL();
-			$userType = $user->isRegistered() ? "User" : "Anonymous";
+			$userType = $user->isRegistered() ? 'User' : 'Anonymous';
 			$cookieDisable = (int)$config->get( 'MatomoAnalyticsDisableCookie' );
 			$forceGetRequest = (int)$config->get( 'MatomoAnalyticsForceGetRequest' );
 			$text .= <<<SCRIPT


### PR DESCRIPTION
Since 1.38 it has been possible that the `SkinAfterBottomScripts` hook could be ran twice. Once is in `OutputPage::tailElement()`, once in `OutputPage::getBottomScripts()`. Since `OutputPage::tailElement()` also runs `OutputPage::getBottomScripts()`, if `OutputPage::tailElement()` is ran, the hook is ran twice and the script here gets added twice. This should prevent that.