### PR TITLE
eslint: Ignore possible timing attacks

### DIFF
--- a/modules/ext.matomoanalytics.oouiform.ooui.js
+++ b/modules/ext.matomoanalytics.oouiform.ooui.js
@@ -85,6 +85,11 @@
 			var hash = location.hash;
 			if ( hash.match( /^#mw-[\w-]+/ ) ) {
 				detectHash();
+			/*
+			 * The next comment makes eslint ignore possible timing attacks when checking if the hash is an empty string
+			 * as this is not something you need a constant-time comparison for
+			*/
+			// eslint-disable-next-line security/detect-possible-timing-attacks
 			} else if ( hash === '' ) {
 				switchMatomoAnalyticsTab( $( '[id*=mw-section-]' ).attr( 'id' ), true );
 			}


### PR DESCRIPTION
Isn't necessary for this check, as it is checking if the hash is an empty string, and will make CI happy