### PR TITLE
Update localization

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,6 +16,7 @@
 	"matomoanalytics-labels-country": "Country",
 	"matomoanalytics-labels-devices": "Devices",
 	"matomoanalytics-labels-os": "OS",
+	"matomoanalytics-labels-pagesviewed": "Top pages",
 	"matomoanalytics-labels-pastmonth": "Page views in the past month",
 	"matomoanalytics-labels-referrer": "Site Referrals",
 	"matomoanalytics-labels-resolution": "Resolution",


### PR DESCRIPTION
The new Matomo update is missing localization for the name of a tab. It is currently showing `⧼matomoanalytics-labels-pagesviewed⧽`. "Top pages" should be a good summary of what is tab is doing.