### PR TITLE
Decode URL before sending to Matomo

### DIFF
--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -105,7 +105,7 @@ class Main implements
 		$mA = new MatomoAnalyticsWiki( period: 30, siteId: $mAId );
 
 		$title = $context->getTitle();
-		$url = $title->getFullURL();
+		$url = rawurldecode( $title->getFullURL() );
 		$data = $mA->getPageViews( $url );
 		$total = array_sum( $data );
 


### PR DESCRIPTION
On the Chinese Undertale and Deltarune wikis our users noticed the info pages always displayed 0 as the view count on pages with Chinese characters, even if those pages were some of the most popular pages on the wiki, e.g. https://zh.undertale.wiki/i/Category:%E6%95%B5%E4%BA%BA.

Tracing through Matomo's code, it turns out that it does not decode the URL when building the search tree. The pages are stored decoded in Matomo, whereas the extension requests pages with encoded path segments, so Matomo returns nothing.

This change replaces instances of %## in the URL returned from Title::getFullURL before sending them to Matomo, which seems to fix the issue.