### PR TITLE
Use DB key instead of prefixed text for Matomo title

### DIFF
--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -55,7 +55,7 @@ class Main implements
 		$serverUrl = $config->get( ConfigNames::ServerURL );
 		$title = $skin->getRelevantTitle();
 
-		$jsTitle = Html::encodeJsVar( $title->getPrefixedText() );
+		$jsTitle = Html::encodeJsVar( $title->getPrefixedDBkey() );
 		$wikiId = Html::encodeJsVar( WikiMap::getCurrentWikiId() );
 
 		$urlTitle = $title->getPrefixedURL();


### PR DESCRIPTION
This is a better way and more clear way to track. Could allow us to better link to articles as well if we want to by having the original DB key we want to link to.  I am not exactly sure if this will actually work to do that though.